### PR TITLE
Separate Target from Image

### DIFF
--- a/jquery.iskip.js
+++ b/jquery.iskip.js
@@ -14,12 +14,17 @@ jQuery.fn.iskip = function(options){
 		options = options || {};
 		options.images = options.images || [];
 		options.method = options.method || "click"
+		options.img = options.img;
 		options.cycle = options.cycle || 1;
 		options.resetMargin = options.resetMargin || 0;
 
     return this.each(function(){
 			var imgArr = [];
+			var target = $(this);
 			var pic = $(this);
+			if(typeof options.img !== 'undefined'){
+				pic = options.img;
+			}
 		// Preload Images
 				$.each(options.images, function(index, record) { var o =$("<img>").attr("src",record);		
 				$("body").append(o); o.hide(); });
@@ -32,35 +37,35 @@ jQuery.fn.iskip = function(options){
 			imgArr.push(options.images[0]);
 
 			if (options.method == "mousemove")
-				pic.mousemove(function(e) {
-					pic.attr("src",imgArr[Math.floor((e.pageX - pic.offset().left) / (pic.width()/imgArr.length))]);
+				target.mousemove(function(e) {
+					pic.attr("src",imgArr[Math.floor((e.pageX - target.offset().left) / (target.width()/imgArr.length))]);
 				});
 
 			if (options.method == "click")
 			{			
 					var follower
 					if (!$.browser.msie)
-					{	follower = $("<div>").css({"z-index":0, "width":"15px", "height":"15px", "position":"absolute", "top": pic.offset().top, "left":pic.offset().left});
-  					$("body").append(follower);
+					{	follower = $("<div>").css({"z-index":0, "width":"15px", "height":"15px", "position":"absolute", "top": target.offset().top, "left":target.offset().left});
+					$("body").append(follower);
 						disableSelection(follower[0]);
 					}
 					disableSelection(pic[0]);
 					var imgSrc, enabled;
-					pic.mousemove(function(e) {
-						if (e.pageX<=pic.offset().left+options.resetMargin || e.pageX > pic.offset().left + pic.width()-options.resetMargin || e.pageY<=pic.offset().top+options.resetMargin || e.pageY>=pic.offset().top+pic.height()-options.resetMargin)
+					target.mousemove(function(e) {
+						if (e.pageX<=target.offset().left+options.resetMargin || e.pageX > target.offset().left + target.width()-options.resetMargin || e.pageY<=target.offset().top+options.resetMargin || e.pageY>=target.offset().top+target.height()-options.resetMargin)
 						{	enabled=false;
 							return false;
 						}
 						if (follower)
 							follower.css({"top": e.pageY-7, "left": e.pageX-7});
 						if (enabled==true)
-							pic.attr("src",imgArr[Math.floor((e.pageX - pic.offset().left) / (pic.width()/imgArr.length))]);
+							pic.attr("src",imgArr[Math.floor((e.pageX - target.offset().left) / (target.width()/imgArr.length))]);
 					})
-					pic.add((follower)?follower:null).mouseup(function() {
+					target.add((follower)?follower:null).mouseup(function() {
 							enabled=false; 
 					}).mousedown(function() { enabled=true; });
 			}
-	});			
+	});
 
 	// Disable text selection
 	function disableSelection(element) {

--- a/readme.md
+++ b/readme.md
@@ -28,9 +28,9 @@ Addtionally by setting a number in cycle tells iSkip how fast to change the imag
 
 	cycle
 
-If you want to have a different target area than the image which is changed, use the ```img``` option and pass in the jQuery object for the image which should change. Run the iskip method on the target.
+If you want to have a different target area than the image which is changed, use the ```img``` option and pass in the jQuery object for the image which should change. Run the ```iskip``` method on the target.
 
-	```$('.thumbnailTarget').iskip({images:array, method:mousemove, cycle:3, img:$('.thumbnailTarget img')});```  
+	$('.thumbnailTarget').iskip({images:array, method:mousemove, cycle:3, img:$('.thumbnailTarget img')}); 
 
 See the statement below for how the iSkip demo was set up on this website.
 

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ The simplest implementation to get iSkip working is by adding the code below. Th
 
 ### Options
 
-You can specify extra options to ad greater control to your iSkip implementation.
+You can specify extra options to add greater control to your iSkip implementation.
 
 There are two methods for iSkip to loop through the images.
 
@@ -27,6 +27,10 @@ There are two methods for iSkip to loop through the images.
 Addtionally by setting a number in cycle tells iSkip how fast to change the images in the container, the lower the number the faster iSkip skips the images.
 
 	cycle
+
+If you want to have a different target area than the image which is changed, use the ```img``` option and pass in the jQuery object for the image which should change. Run the iskip method on the target.
+
+	```$('.thumbnailTarget').iskip({images:array, method:mousemove, cycle:3, img:$('.thumbnailTarget img')});```  
 
 See the statement below for how the iSkip demo was set up on this website.
 


### PR DESCRIPTION
I added a small extension to this plugin which allows you to specify a separate target from the image which changes. I used it in a thumbnail gallery(200x400px, let's say) where some of the images are only 40px wide. I made the target for all of the thumbnails the div around the image so that the user doesn't have to know how wide the image is.
